### PR TITLE
sub-square constraints

### DIFF
--- a/sudoku.py
+++ b/sudoku.py
@@ -130,7 +130,7 @@ def main():
 
     # Constraint: Each sub-square cannot have duplicates
     # Build indices of a basic subsquare
-    subsquare_indices = [(row, col) for row in range(3) for col in range(3)]
+    subsquare_indices = [(row, col) for row in range(m) for col in range(m)]
 
     # Build full sudoku array
     for r_scalar in range(m):


### PR DESCRIPTION
Sub-square constraints currently work correctly for 9x9 sudokus only:
```
subsquare_indices = [(row, col) for row in range(3) for col in range(3)]
```
This pull request changes this line to the following, so that arbitray sized sudokus can be handled:
```
subsquare_indices = [(row, col) for row in range(m) for col in range(m)]
```

Regards,
-Hayk