### PR TITLE
Prevent starting values from being overwritten

### DIFF
--- a/sudoku.py
+++ b/sudoku.py
@@ -174,6 +174,14 @@ def main():
     for label in solution_list:
         coord, digit = label.split('_')
         row, col = map(int, coord.split(','))
+
+        if matrix[row][col] > 0:
+            # the returned solution is not optimal and either tried to
+            # overwrite one of the starting values, or returned more than
+            # one value for the position. In either case the solution is
+            # likely incorrect.
+            continue
+
         matrix[row][col] = int(digit)
 
     for line in matrix:


### PR DESCRIPTION
An alternative would be to fix more variables https://github.com/dwave-examples/sudoku/blob/7411b7fcdcc7045f8346516da79170e3a00a6dcf/sudoku.py#L153
Specifically, when we know the value of a certain column, we could fix that variable in the BQM to 1 and then all other variables in that column to 0. This change is less invasive though.